### PR TITLE
Update Create Bookmark from Current Tab in Chrome.applescript

### DIFF
--- a/scripts/Create Bookmark from Current Tab in Chrome.applescript
+++ b/scripts/Create Bookmark from Current Tab in Chrome.applescript
@@ -1,15 +1,16 @@
 (*
 	
 *)
+
 tell application "Google Chrome"
 	if active tab of front window exists then
 		set active_tab to active tab of front window
-		
 		set tab_title to title of active_tab
 		set tab_address to URL of active_tab
-		
+		copy selection of active_tab
+		set selected_text to the clipboard
 		tell application "Spillo"
-			show create bookmark panel with properties {url:tab_address, title:tab_title}
+			show create bookmark panel with properties {url:tab_address, title:tab_title, desc:selected_text}
 		end tell
 	end if
 end tell

--- a/scripts/Create Bookmark from Current Tab in Chrome.applescript
+++ b/scripts/Create Bookmark from Current Tab in Chrome.applescript
@@ -1,14 +1,15 @@
 (*
 	
 *)
-
 tell application "Google Chrome"
 	if active tab of front window exists then
 		set active_tab to active tab of front window
+		
 		set tab_title to title of active_tab
 		set tab_address to URL of active_tab
 		copy selection of active_tab
 		set selected_text to the clipboard
+		
 		tell application "Spillo"
 			show create bookmark panel with properties {url:tab_address, title:tab_title, desc:selected_text}
 		end tell


### PR DESCRIPTION
Added ability to populate Spillo's Description field with the currently selected text in the Chrome tab. (It is optional behavior: if no selection, Description is not populated.) 

Note: Due to Chrome's refusal to execute javascript via Applescript, we must rely on the clipboard, so the current clipboard contents are replaced with selected text when this script runs. Code could be added to save the clipboard's current contents, do the Spillo automation and then place the original contents back on the clipboard at the script's end.
